### PR TITLE
year in url route

### DIFF
--- a/app.py
+++ b/app.py
@@ -27,11 +27,10 @@ def api_ping():
 
 
 ### historical infra map ###
-@app.route("/api/map/historical/")
-def getMapHistorical():
+@app.route("/api/map/historical/<year>")
+def getMapHistorical(year):
     # extract argument from request
-    date = request.args.get('date')
-    return jsonify(getters.getMatchedFeaturesHistorical(date))
+    return jsonify(getters.getMatchedFeaturesHistorical(year))
 
 ### general map ###
 @app.route("/api/map/general/<kind>")


### PR DESCRIPTION
Fixed historical map route, year argument now part of api route.

close osoc19/cycling-up-frontend#72