### PR TITLE
Add bm_bike:rt_counting layer to fetch process

### DIFF
--- a/api/swagger/get_map_general.yml
+++ b/api/swagger/get_map_general.yml
@@ -13,6 +13,7 @@ parameters:
       - bike_shop
       - bike_villo
       - bike_icr
+      - bike_live_counting
 responses:
   200:
     description: Successful GeoJSon data about the requested map
@@ -22,44 +23,44 @@ responses:
       application/json:
         type: FeatureCollection
         features:
-        - type: Feature
-          geometry:
-            type: Point
-            coordinates:
-            - 102
-            - 0.5
-          properties:
-            prop0: value0
-        - type: Feature
-          geometry:
-            type: LineString
-            coordinates:
-            - - 102
-              - 0
-            - - 103
-              - 1
-            - - 104
-              - 0
-            - - 105
-              - 1
-          properties:
-            prop0: value0
-            prop1: 0
-        - type: Feature
-          geometry:
-            type: Polygon
-            coordinates:
-            - - - 100
-                - 0
-              - - 101
-                - 0
-              - - 101
-                - 1
-              - - 100
-                - 1
-              - - 100
-                - 0
-          properties:
-            prop0: value0
-            prop1:
-              this: that
+          - type: Feature
+            geometry:
+              type: Point
+              coordinates:
+                - 102
+                - 0.5
+            properties:
+              prop0: value0
+          - type: Feature
+            geometry:
+              type: LineString
+              coordinates:
+                - - 102
+                  - 0
+                - - 103
+                  - 1
+                - - 104
+                  - 0
+                - - 105
+                  - 1
+            properties:
+              prop0: value0
+              prop1: 0
+          - type: Feature
+            geometry:
+              type: Polygon
+              coordinates:
+                - - - 100
+                    - 0
+                  - - 101
+                    - 0
+                  - - 101
+                    - 1
+                  - - 100
+                    - 1
+                  - - 100
+                    - 0
+            properties:
+              prop0: value0
+              prop1:
+                this: that

--- a/process_data/mobigis_fetch.json
+++ b/process_data/mobigis_fetch.json
@@ -1,30 +1,33 @@
 {
-    "base_url" : "http://data-mobility.brussels/geoserver/bm_bike/wfs?service=wfs&version=1.1.0&request=GetFeature&srsName=EPSG:4326&outputFormat=json", 
-    "items" :    [
+    "base_url": "http://data-mobility.brussels/geoserver/bm_bike/wfs?service=wfs&version=1.1.0&request=GetFeature&srsName=EPSG:4326&outputFormat=json",
+    "items": [
         {
-            "url" : "&typeName=bm_bike:ac",
-            "save_as" : "bike_infra.json" 
+            "url": "&typeName=bm_bike:ac",
+            "save_as": "bike_infra.json"
         },
         {
-            "url" : "&typeName=bm_bike:bicycle_parking",
-            "save_as" : "bike_parking.json" 
+            "url": "&typeName=bm_bike:bicycle_parking",
+            "save_as": "bike_parking.json"
         },
         {
-            "url" : "&typeName=bm_bike:villo",
-            "save_as" : "bike_villo.json"
+            "url": "&typeName=bm_bike:villo",
+            "save_as": "bike_villo.json"
         },
         {
-            "url" : "&typeName=bm_bike:bicyclepump",
-            "save_as" : "bike_pump.json"
+            "url": "&typeName=bm_bike:bicyclepump",
+            "save_as": "bike_pump.json"
         },
         {
-            "url" : "&typeName=bm_bike:bicyclestore",
-            "save_as" : "bike_shop.json"
+            "url": "&typeName=bm_bike:bicyclestore",
+            "save_as": "bike_shop.json"
         },
         {
-            "url" : "&typeName=bm_bike:icr",
-            "save_as" : "bike_icr.json"
+            "url": "&typeName=bm_bike:icr",
+            "save_as": "bike_icr.json"
+        },
+        {
+            "url": "&typeName=bm_bike:rt_counting",
+            "save_as": "bike_live_counting.json"
         }
-       
     ]
 }


### PR DESCRIPTION
## Description

- Fetch `bm_bike:rt_counting` layer from Mobigis and add it to fetch process
- Update documentation

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).


## Checklist:
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation.
- [ ] My changes generate no new warnings.
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes.
- [ ] Any dependent changes have been merged and published in downstream modules

